### PR TITLE
Use Core Module FTDI uart since R1 is outdated.

### DIFF
--- a/app/application.h
+++ b/app/application.h
@@ -11,7 +11,7 @@
 
 #if CORE_MODULE
 #define FIRMWARE "bcf-gateway-core-module"
-#define TALK_OVER_CDC 1
+#define TALK_OVER_CDC 0
 #define GPIO_LED BC_GPIO_LED
 #else
 #define FIRMWARE "bcf-gateway-usb-dongle"


### PR DESCRIPTION
Since R1 is no longer manufactured, I would set the define to use FTDI uart which is on all Core Modules REV2.